### PR TITLE
Add iterable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ index.query('find {foo: =="bar"}').then(iter => {
 }
 ```
 
+The iterator is also a iterable, so you can use it in a `for ... of` loop:
+
+```javascript
+index.query('find {foo: =="bar"}').then(iter => {
+    for (let value of iter) {
+        console.log(value);
+    }
+}
+```
+
 ## Deleting Documents
 
 You can delete documents by passing in an array of `_id`s of the documents to the `.delete(...)` method. It returns an array of booleans where each elements indicates whether the deletion of the individual document was successful or not.

--- a/lib/noise.js
+++ b/lib/noise.js
@@ -124,6 +124,10 @@ var newDb = function(q, socket, connId) {
                         return;
                     }
                     var iter = {
+                        // http://2ality.com/2013/06/iterators-generators.html
+                        [Symbol.iterator]() {
+                            return this;
+                        },
                         next: () => {
                             var resp = addon.queryNext(connId);
                             if (resp.done) {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,23 @@ exports['test basic'] = function(assert, done) {
     });
 }
 
+exports['test iterable'] = function(assert, done) {
+    var index = noise.open("iterabletesttest", true);
+    index.add([{_id:"a",foo:"bar"}, {_id:"b", foo:"baz"}]).then(resp => {
+        assert.deepEqual(resp, ["a","b"], "docs created");
+        return index.query('find {foo: =="bar" || foo: =="baz"}')
+    }).then(iter => {
+        let ids = [];
+        for (let value of iter) {
+            ids.push(value);
+        }
+        assert.deepEqual(ids, ["a", "b"], "doc a and b found");
+        done();
+    }).catch(error => {
+        console.log(error);
+    });
+}
+
 exports['test bad open'] = function(assert, done) {
     var index = noise.open("", true);
     index.add([{_id:"a",foo:"bar"}, {_id:"b", foo:"baz"}]).then(resp => {


### PR DESCRIPTION
It's no possible to iterate over the results via `for ... of` loop:

    index.query('find {foo: =="bar"}').then(iter => {
        for (let value of iter) {
            console.log(value);
        }
    }