### PR TITLE
Pin neon-cli to 0.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "^2.2.0",
-    "neon-cli": "^0.1.13",
+    "neon-cli": "0.1.13",
     "node-ipc": "^8.10.3",
     "unix-stream": "^1.0.2"
   },


### PR DESCRIPTION
The most recent 0.1.x (0.1.15) broke the build, hence pin it to
0.1.13 for now until it is fixed.