### PR TITLE
Bug fix release 0.7.1

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,6 @@ neon-build = "0.1.13"
 
 [dependencies]
 neon = "0.1.13"
-noise_search = "0.6.2"
+noise_search = "0.6.3"
 unix_socket = "0.5.0"
 lazy_static = "0.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noise-search",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Noise for Node.js",
   "main": "lib/noise.js",
   "author": "Damien Katz <me@damienkatz.com>",


### PR DESCRIPTION
Currently `npm intall noise-search` fails on my machine. With bumping
Noise to version 0.6.3 it should work again.