### PR TITLE
chore: gitignore native/artifacts.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+native/artifacts.json
 native/target
 native/index.node
 native/Cargo.lock


### PR DESCRIPTION
The `native/artifacts.json` is generated by Neon when the Rust part
is compiled. As it is generated, don't check it in, but ignore it.