### PR TITLE
chore: update to latest Noise release 0.8.0

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,6 @@ neon-build = "0.10"
 
 [dependencies]
 neon = "0.10"
-noise_search = "0.7.0"
+noise_search = "0.8.0"
 unix_socket = "0.5.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION
The new Noise release doesn't contain any functional changes, it was
onle code cleanups.